### PR TITLE
Improved error message when wrong boundary conditions are specified

### DIFF
--- a/pde/grids/boundaries/axes.py
+++ b/pde/grids/boundaries/axes.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ..base import GridBase, PeriodicityError
 from .axis import BoundaryPair, BoundaryPairData, get_boundary_axis
+from .local import BCDataError
 
 BoundariesData = Union[BoundaryPairData, Sequence[BoundaryPairData]]
 
@@ -26,20 +27,21 @@ class Boundaries(list):
     def __init__(self, boundaries):
         """ initialize with a list of boundaries """
         if len(boundaries) == 0:
-            raise ValueError("List of boundaries must not be empty")
+            raise BCDataError("List of boundaries must not be empty")
 
         # extract grid
         self.grid = boundaries[0].grid
 
         # check dimension
         if len(boundaries) != self.grid.num_axes:
-            raise ValueError(f"Need boundary conditions for {self.grid.num_axes} axes")
+            raise BCDataError(f"Need boundary conditions for {self.grid.num_axes} axes")
+
         # check consistency
         for axis, boundary in enumerate(boundaries):
             if boundary.grid != self.grid:
-                raise ValueError("Boundaries are not defined on the same grid")
+                raise BCDataError("Boundaries are not defined on the same grid")
             if boundary.axis != axis:
-                raise ValueError(
+                raise BCDataError(
                     "Boundaries need to be ordered like the respective axes"
                 )
             if boundary.periodic != self.grid.periodic[axis]:
@@ -120,7 +122,7 @@ class Boundaries(list):
 
         if bcs is None:
             # none of the logic worked
-            raise ValueError(
+            raise BCDataError(
                 f"Unsupported boundary format: `{boundaries}`. " + cls.get_help()
             )
 

--- a/pde/grids/boundaries/axis.py
+++ b/pde/grids/boundaries/axis.py
@@ -16,7 +16,7 @@ from numba.extending import register_jitable
 
 from ...tools.typing import NumberOrArray
 from ..base import DomainError, GridBase
-from .local import BCBase, BoundaryData, NeumannBC, _make_get_arr_1d
+from .local import BCBase, BCDataError, BoundaryData, NeumannBC, _make_get_arr_1d
 
 BoundaryPairData = Union[
     Dict[str, BoundaryData], BoundaryData, Tuple[BoundaryData, BoundaryData]
@@ -171,7 +171,7 @@ class BoundaryPair(BoundaryAxisBase):
                     grid, axis, upper=True, data=data_copy.pop("high"), rank=rank
                 )
                 if data_copy:
-                    raise ValueError(f"Data items {data_copy.keys()} were not used.")
+                    raise BCDataError(f"Data items {data_copy.keys()} were not used.")
             else:
                 # one condition for both sides
                 low = BCBase.from_data(grid, axis, upper=False, data=data, rank=rank)
@@ -190,7 +190,7 @@ class BoundaryPair(BoundaryAxisBase):
                 data_len = len(data)
             except TypeError:
                 # if len is not supported, the format must be wrong
-                raise ValueError(
+                raise BCDataError(
                     f"Unsupported boundary format: `{data}`. " + cls.get_help()
                 )
             else:
@@ -204,7 +204,7 @@ class BoundaryPair(BoundaryAxisBase):
                     )
                 else:
                     # if the length is strange, the format must be wrong
-                    raise ValueError(
+                    raise BCDataError(
                         "Expected two conditions for the two sides of the axis, but "
                         f"got `{data}`. " + cls.get_help()
                     )

--- a/pde/grids/boundaries/local.py
+++ b/pde/grids/boundaries/local.py
@@ -44,6 +44,12 @@ from ..base import GridBase
 BoundaryData = Union[Dict, str, "BCBase"]
 
 
+class BCDataError(ValueError):
+    """ exception that signals that incompatible data was supplied for the BC """
+
+    pass
+
+
 def _get_arr_1d(arr, idx: Tuple[int, ...], axis: int) -> Tuple[np.ndarray, int, Tuple]:
     """extract the 1d array along axis at point idx
 
@@ -572,7 +578,7 @@ class BCBase(metaclass=ABCMeta):
         """
         # raise warning to mention problem with legacy code (bug fixed 2021-01-18)
         if condition == "no-flux":
-            raise ValueError(
+            raise BCDataError(
                 "Specifying the boundary condition 'no-flux' is no longer supported "
                 "since it introduced a bug when specifying flux conditions. To impose "
                 "no flux conditions, please decide whether you need to impose a "
@@ -584,7 +590,7 @@ class BCBase(metaclass=ABCMeta):
         try:
             boundary_class = cls._conditions[condition]
         except KeyError:
-            raise ValueError(
+            raise BCDataError(
                 f"Boundary condition `{condition}` not defined. " + cls.get_help()
             )
 
@@ -626,7 +632,7 @@ class BCBase(metaclass=ABCMeta):
             b_type, b_value = data.popitem()
 
         else:
-            raise ValueError(
+            raise BCDataError(
                 f"Boundary conditions `{str(list(data.keys()))}` are not supported."
             )
 
@@ -677,7 +683,7 @@ class BCBase(metaclass=ABCMeta):
             return cls.from_str(grid, axis, upper=upper, condition=data, rank=rank)
 
         else:
-            raise ValueError(
+            raise BCDataError(
                 f"Unsupported boundary format: `{data}`. " + cls.get_help()
             )
 

--- a/pde/trackers/base.py
+++ b/pde/trackers/base.py
@@ -138,6 +138,10 @@ class TrackerCollection:
         self.tracker_action_times = []
         self.time_next_action = np.inf
 
+    def __len__(self) -> int:
+        """ returns the number of trackers in the collection """
+        return len(self.trackers)
+
     @classmethod
     def from_data(
         cls, data: TrackerCollectionDataType, **kwargs


### PR DESCRIPTION
This is particularly crucial when using the PDE class, which otherwise
would silently ignore such errors and fail at a different stage