### PR TITLE
Added user-defined boundary conditions

### DIFF
--- a/pde/solvers/explicit.py
+++ b/pde/solvers/explicit.py
@@ -28,7 +28,7 @@ class ExplicitSolver(SolverBase):
         scheme: str = "euler",
         backend: str = "auto",
         adaptive: bool = False,
-        tolerance: float = 1e-4,
+        tolerance: float = 1e-5,
     ):
         """
         Args:


### PR DESCRIPTION
These are special boundary conditions that are never enforced
automatically, e.g., when an operator with such boundary conditions is
called, the ghost cells are simply not modified, similar to bc="none".
Instead, calling set_ghost_cells with `args={"user": value}` will allow
setting ghost points explicitly. This is an advanced feature that should
be used with care.

We also changed the default tolerance of the explicit adaptive Euler
method from 1e-4 to 1e-5 to avoid some common problems.