### PR TITLE
Allow easier splitting of fields onto MPI nodes

### DIFF
--- a/pde/grids/base.py
+++ b/pde/grids/base.py
@@ -27,6 +27,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     Union,
 )
 
@@ -132,7 +133,7 @@ class PeriodicityError(RuntimeError):
 class GridBase(metaclass=ABCMeta):
     """Base class for all grids defining common methods and interfaces"""
 
-    _subclasses: Dict[str, "GridBase"] = {}  # all classes inheriting from this
+    _subclasses: Dict[str, Type[GridBase]] = {}  # all classes inheriting from this
     _operators: Dict[str, OperatorInfo] = {}  # all operators defined for the grid
 
     # properties that are defined in subclasses
@@ -174,7 +175,7 @@ class GridBase(metaclass=ABCMeta):
         """register all subclassess to reconstruct them later"""
         super().__init_subclass__(**kwargs)
         cls._subclasses[cls.__name__] = cls
-        cls._operators: Dict[str, Callable] = {}
+        cls._operators = {}
 
     @classmethod
     def from_state(cls, state: Union[str, Dict[str, Any]]) -> GridBase:

--- a/pde/pdes/pde.py
+++ b/pde/pdes/pde.py
@@ -384,8 +384,13 @@ class PDE(PDEBase):
             if np.isscalar(value):
                 pass  # this simple case is fine
             elif isinstance(value, DataFieldBase):
-                value.grid.assert_grid_compatible(state.grid)
-                value = value.data  # just keep the actual discretized data
+                # constant is a field, which might need to be split in MPI simulation
+                if state.grid._mesh is not None:
+                    value.grid.assert_grid_compatible(state.grid._mesh.basegrid)
+                    value = state.grid._mesh.split_field_data_mpi(value.data)
+                else:
+                    value.grid.assert_grid_compatible(state.grid)
+                    value = value.data  # just keep the actual discretized data
             else:
                 raise TypeError(f"Constant has unsupported type {value.__class__}")
 


### PR DESCRIPTION
* Fix a bug where the `PDE` class would not split constants