### PR TITLE
Extended expression BCs to also accept python functions

### DIFF
--- a/docs/source/manual/advanced_usage.rst
+++ b/docs/source/manual/advanced_usage.rst
@@ -59,10 +59,12 @@ There exist also special boundary conditions that impose a more complex value of
 field (:code:`bc='value_expression'`) or its derivative
 (:code:`bc='derivative_expression'`). Beyond the spatial coordinates that are already
 supported for the constant conditions above, the expressions of these boundary
-conditions can depend on the time variable :code:`t`. Note that PDEs need to supply the
-current time when setting the boundary conditions, e.g., when applying the differential
-operators. The pre-defined PDEs and the general class :class:`~pde.pdes.pde.PDE` already
-support time-dependent boundary conditions.
+conditions can depend on the time variable :code:`t`. Moreover, these boundary
+conditions also except python functions (with signature `adjacent_value, dx, *coords, t`),
+thus greatly enlarging the flexibility with which boundary conditions can be expressed.
+Note that PDEs need to supply the current time `t` when setting the boundary conditions,
+e.g., when applying the differential operators. The pre-defined PDEs and the general
+class :class:`~pde.pdes.pde.PDE` already support time-dependent boundary conditions.
 
 One important aspect about boundary conditions is that they need to respect the
 periodicity of the underlying grid. For instance, in a 2d grid with one periodic axis,

--- a/examples/heterogeneous_bcs.py
+++ b/examples/heterogeneous_bcs.py
@@ -1,0 +1,40 @@
+r"""
+Heterogeneous boundary conditions
+=================================
+
+This example implements a `spatially coupled SIR model 
+<https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology>`_ with 
+the following dynamics for the density of susceptible, infected, and recovered
+individuals:
+
+.. math::
+
+    \partial_t s &= D \nabla^2 s - \beta is \\
+    \partial_t i &= D \nabla^2 i + \beta is - \gamma i \\
+    \partial_t r &= D \nabla^2 r + \gamma i
+
+Here, :math:`D` is the diffusivity, :math:`\beta` the infection rate, and
+:math:`\gamma` the recovery rate.
+"""
+
+import numpy as np
+
+from pde import CartesianGrid, DiffusionPDE, ScalarField
+
+# define grid and an initial state
+grid = CartesianGrid([[-5, 5], [-5, 5]], 32)
+field = ScalarField(grid)
+
+# define the boundary conditions, which here are calculated from a function
+def bc_value(adjacent_value, dx, x, y, t):
+    """return boundary value"""
+    return np.sign(x)
+
+
+bc_x = "derivative"
+bc_y = ["derivative", {"value_expression": bc_value}]
+
+# define and solve a simple diffusion equation
+eq = DiffusionPDE(bc=[bc_x, bc_y])
+res = eq.solve(field, t_range=10, dt=0.01, backend="numpy")
+res.plot()

--- a/pde/grids/boundaries/__init__.py
+++ b/pde/grids/boundaries/__init__.py
@@ -19,7 +19,7 @@ conditions for each axes:
 
     field = ScalarField(UnitGrid([16, 16], periodic=[True, False]))
     field.laplace(bc=[bc_x, bc_y])
-    
+
 If an axis is periodic (like the first one in the example above), the only valid
 boundary conditions are 'periodic' and its cousin 'anti-periodic', which imposes
 opposite signs on both sides. For non-periodic axes (e.g., the second axis),
@@ -31,7 +31,7 @@ derivative in the normal direction (specified by `{'derivative': DERIV}`). The s
 choices for the example above could be
 
 .. code-block:: python
-    
+
     bc_x = "periodic"
     bc_y = ({"value": 2}, {"derivative": -1})
 
@@ -43,14 +43,14 @@ given as a string that can be parsed by `sympy`. They can depend on all coordina
 the grid. An alternative boundary condition to the example above could thus read
 
 .. code-block:: python
-    
+
     bc_y = ({"value": "y**2"}, {"derivative": "-sin(x)"})
 
 
 Warning:
     To interpret arbitrary expressions, the package uses :func:`exec`. It
     should therefore not be used in a context where malicious input could occur.
-    
+
 Inhomogeneous values can also be specified by directly supplying an array, whose shape
 needs to be compatible with the boundary, i.e., it needs to have the same shape as the
 grid but with the dimension of the axis along which the boundary is specified removed. 
@@ -59,7 +59,7 @@ The package also supports mixed boundary conditions (depending on both the value
 and the derivative of the field) and imposing a second derivative. An example is
 
 .. code-block:: python
-    
+
     bc_y = ({"type": "mixed", "value": 2, "const": 7},
             {"curvature": 2})
 
@@ -87,10 +87,10 @@ conditions for periodic axis and a vanishing derivative or value otherwise. For 
 
     field = ScalarField(UnitGrid([16, 16], periodic=[True, False]))
     field.laplace(bc="auto_periodic_neumann")
-    
+
 enforces periodic boundary conditions on the first axis, while the second one
 has standard Neumann conditions.
-    
+
 Note:
     Derivatives are given relative to the outward normal vector, such that positive
     derivatives correspond to a function that increases across the boundary. 
@@ -106,19 +106,20 @@ The :mod:`~pde.grids.boundaries` package defines the following classes:
 * :class:`~pde.grids.boundaries.local.DirichletBC`:
   Imposing a constant value of the field at the boundary
 * :class:`~pde.grids.boundaries.local.ExpressionValueBC`:
-  Imposing the value of the field at the boundary given by an expression
+  Imposing the value of the field at the boundary given by an expression or a python
+  function
 * :class:`~pde.grids.boundaries.local.NeumannBC`:
   Imposing a constant derivative of the field in the outward normal direction at the
   boundary
 * :class:`~pde.grids.boundaries.local.ExpressionDerivativeBC`:
   Imposing the derivative of the field in the outward normal direction at the
-  boundary given by an expression
+  boundary given by an expression or a python function
 * :class:`~pde.grids.boundaries.local.MixedBC`:
   Imposing the derivative of the field in the outward normal direction proportional to
   its value at the boundary  
 * :class:`~pde.grids.boundaries.local.CurvatureBC`:
   Imposing a constant second derivative (curvature) of the field at the boundary
-  
+
 
 There are corresponding classes that only affect the normal component of a field, which
 can be useful when dealing with vector and tensor fields:

--- a/pde/tools/docstrings.py
+++ b/pde/tools/docstrings.py
@@ -25,7 +25,7 @@ DOCSTRING_REPLACEMENTS = {
        """,
     "ARG_BOUNDARIES": """
         Boundary conditions are generally given as a list with one condition for each
-        axis. For periodic axis, only periodic boundary conditions are allowed
+        axis. For periodic axes, only periodic boundary conditions are allowed
         (indicated by 'periodic' and 'anti-periodic'). For non-periodic axes, different
         boundary conditions can be specified for the lower and upper end (using a tuple
         of two conditions). For instance, Dirichlet conditions enforcing a value NUM

--- a/tests/pdes/test_diffusion_pdes.py
+++ b/tests/pdes/test_diffusion_pdes.py
@@ -95,7 +95,14 @@ def test_diffusion_time_dependent_bcs(backend):
     eq = DiffusionPDE(bc={"value_expression": "Heaviside(t - 1.5)"})
 
     storage = MemoryStorage()
-    eq.solve(field, t_range=10, dt=1e-2, backend=backend, tracker=storage.tracker(1))
+    eq.solve(
+        field,
+        t_range=10,
+        dt=1e-2,
+        adaptive=True,
+        backend=backend,
+        tracker=storage.tracker(1),
+    )
 
     np.testing.assert_allclose(storage[1].data, 0)
     np.testing.assert_allclose(storage[-1].data, 1, rtol=1e-3)


### PR DESCRIPTION
* Time `t` is no passed as a positional argument instead of a keyword argument internally
* Adjusted documentation to reflect new possibilities to set BCs
* Added an example to display the new functionality