### PR TITLE
Fixed problems with MPI simulations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ import pde
 version = pde.__version__.split("-")[0]
 release = pde.__version__
 
-from create_requirements import MIN_PYTHON_VERSION, MAX_PYTHON_VERSION
+from create_requirements import MAX_PYTHON_VERSION, MIN_PYTHON_VERSION
 
 # make the parameters available in RST
 rst_prolog = f"""

--- a/docs/source/manual/performance.rst
+++ b/docs/source/manual/performance.rst
@@ -123,7 +123,7 @@ Saving this script as `multiprocessing.py`, we can evoke a parallel simulation u
 Here, the number `2` determines the number of cores that will be used.
 Note that macOS might require an additional hint on how to connect the processes even
 when they are run on the same machine (e.g., your workstation). It might help to run
-:code:`mpiexec -n 2 -host localhost python3 multiprocessing.py` in this case.
+:code:`mpiexec -n 2 -host localhost:2 python3 multiprocessing.py` in this case.
 
 In the example above, two python processes will start in parallel and run independently
 at first.

--- a/examples/mpi_parallel_run.py
+++ b/examples/mpi_parallel_run.py
@@ -5,7 +5,9 @@ Use multiprocessing via MPI
 Use multiple cores to solve a PDE. The implementation here uses the `Message Passing 
 Interface (MPI) <https://en.wikipedia.org/wiki/Message_Passing_Interface>`_, and the
 script thus needs to be run using :code:`mpiexec -n 2 python mpi_parallel_run.py`, where
-`2` denotes the number of cores used.
+`2` denotes the number of cores used. Note that macOS might require an additional hint
+on how to connect the processes. The following line might work:
+    `mpiexec -n 2 -host localhost:2 python3 mpi_parallel_run.py`
 
 Such parallel simulations need extra care, since multiple instances of the same program
 are started. In particular, in the example below, the initial state is created on all

--- a/pde/grids/_mesh.py
+++ b/pde/grids/_mesh.py
@@ -699,7 +699,7 @@ class GridMesh:
         """
         from mpi4py.MPI import COMM_WORLD
 
-        return COMM_WORLD.gather(data, root=0)
+        return COMM_WORLD.gather(data, root=0)  # type: ignore
 
     def allgather(self, data: TData) -> List[TData]:
         """gather a value from reach node and sends them to all nodes
@@ -712,7 +712,7 @@ class GridMesh:
         """
         from mpi4py.MPI import COMM_WORLD
 
-        return COMM_WORLD.allgather(data)
+        return COMM_WORLD.allgather(data)  # type: ignore
 
     @plot_on_axes()
     def plot(self, ax, **kwargs):

--- a/pde/grids/boundaries/local.py
+++ b/pde/grids/boundaries/local.py
@@ -732,8 +732,10 @@ class _MPIBC(BCBase):
                 The MPI node (the subgrid ID) this BC is associated with
         """
         super().__init__(mesh[node_id], axis, upper, rank=rank)
-        self._neighbor_id = mesh.get_neighbor(axis, upper, node_id=node_id)
-        assert self._neighbor_id is not None
+        neighbor_id = mesh.get_neighbor(axis, upper, node_id=node_id)
+        if neighbor_id is None:
+            raise RuntimeError("No neighboring cell for this boundary")
+        self._neighbor_id = neighbor_id
         self._mpi_flag = mesh.get_boundary_flag(self._neighbor_id, upper)
 
         # determine indices for reading and writing data
@@ -1818,7 +1820,7 @@ class ConstBC1stOrderBase(ConstBCBase):
 
         if self.homogeneous:
 
-            @nb.jit
+            @jit()
             def virtual_point(
                 arr: np.ndarray, idx: Tuple[int, ...], args=None
             ) -> float:
@@ -1832,7 +1834,7 @@ class ConstBC1stOrderBase(ConstBCBase):
 
         else:
 
-            @nb.jit
+            @jit
             def virtual_point(
                 arr: np.ndarray, idx: Tuple[int, ...], args=None
             ) -> float:

--- a/pde/solvers/controller.py
+++ b/pde/solvers/controller.py
@@ -34,10 +34,14 @@ class Controller:
     care of trackers that analyze and modify the state periodically.
     """
 
-    # set a function to determine the current time for profiling purposes. We generally
-    # use the more accurate time.process_time, but better performance may be obtained by
-    # the faster time.time. This will only affect simulations with many iterations.
-    get_current_time = time.process_time
+    diagnostics: Dict[str, Any]
+    """dict: diagnostic information (available after simulation finished)"""
+
+    _get_current_time: Callable = time.process_time
+    """callable: function to determine the current time for profiling purposes. We
+    generally use the more accurate :func:`time.process_time`, but better performance
+    may be obtained by the faster :func:`time.time`. This will only affect simulations
+    with many iterations."""
 
     def __init__(
         self,
@@ -71,7 +75,7 @@ class Controller:
 
         # initialize some diagnostic information
         self.info: Dict[str, Any] = {}
-        self.diagnostics: Dict[str, Any] = {
+        self.diagnostics = {
             "controller": self.info,
             "package_version": __version__,
         }
@@ -149,7 +153,7 @@ class Controller:
         """
         # gather basic information
         t_start, t_end = self.t_range
-        get_time = self.get_current_time  # type: ignore
+        get_time = self._get_current_time
 
         # initialize solver information
         self.info["t_start"] = t_start
@@ -293,11 +297,11 @@ class Controller:
     ) -> Optional[TState]:
         """run the simulation
 
-        Diagnostic information about the solver procedure are available in the
-        `diagnostics` property of the instance after this function has been called.
+        Diagnostic information about the solver are available in the
+        :attr:`~Controller.diagnostics` property after this function has been called.
 
         Args:
-            state:
+            initial_state (:class:`~pde.fields.base.FieldBase`):
                 The initial state of the simulation. This state will be copied and thus
                 not modified by the simulation. Instead, the final state will be
                 returned and trackers can be used to record intermediate states.

--- a/pde/solvers/explicit_mpi.py
+++ b/pde/solvers/explicit_mpi.py
@@ -118,16 +118,12 @@ class ExplicitMPISolver(ExplicitSolver):
         """return helper function that synchronizes errors between multiple processes"""
         if mpi.parallel_run:
             # in a parallel run, we need to return the maximal error
-            from numba_mpi import Operator
-
             from ..tools.mpi import mpi_allreduce
-
-            operator_max_int = int(Operator.MAX)
 
             @register_jitable
             def synchronize_errors(error: float) -> float:
                 """return maximal error accross all cores"""
-                return mpi_allreduce(error, operator_max_int)  # type: ignore
+                return mpi_allreduce(error, "MAX")  # type: ignore
 
             return synchronize_errors  # type: ignore
         else:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -150,7 +150,7 @@ def run_unit_tests(
         # run pytest using MPI with two cores
         args = ["mpiexec", "-n", "2"]
         if sys.platform == "darwin":
-            args += ["-host", "localhost"]
+            args += ["-host", "localhost:2"]
     else:
         args = []
 
@@ -171,6 +171,10 @@ def run_unit_tests(
     if runinteractive:
         args.append("--runinteractive")  # also run interactive tests
     if use_mpi:
+        try:
+            import numba_mpi  # @UnusedImport
+        except ImportError:
+            raise RuntimeError("Moduled `numba_mpi` is required to test with MPI")
         args.append("--use_mpi")  # only run tests requiring MPI multiprocessing
 
     # fail early if requested

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def pytest_collection_modifyitems(config, items):
     runslow = config.getoption("--runslow", default=False)
     runinteractive = config.getoption("--runinteractive", default=False)
     use_mpi = config.getoption("--use_mpi", default=False)
-    has_numba_mpi = module_available("numba_mpi")
+    has_numba_mpi = module_available("numba_mpi") and module_available("mpi4py")
 
     # prepare markers
     skip_cov = pytest.mark.skip(reason="skipped during coverage run")


### PR DESCRIPTION
* Used numba.overload to implement specific mpi functions (instead of always compiling)
* Overhauled MPI Operator interface
* Adjusted how `mpiexec` is called for newer macOStodo

* Multiple smaller improvements in documentation