### PR TITLE
Make `make_derivative` and `make_derivative2` public methods

### DIFF
--- a/pde/grids/operators/__init__.py
+++ b/pde/grids/operators/__init__.py
@@ -11,6 +11,10 @@ methods defined on fields and grids.
    cylindrical_sym
    polar_sym
    spherical_sym
+
+   make_derivative
+   make_derivative2
 """
 
 from . import cartesian, cylindrical_sym, polar_sym, spherical_sym
+from .common import make_derivative, make_derivative2

--- a/pde/grids/operators/cartesian.py
+++ b/pde/grids/operators/cartesian.py
@@ -27,7 +27,12 @@ from ...tools.numba import jit
 from ...tools.typing import OperatorType
 from ..boundaries import Boundaries
 from ..cartesian import CartesianGrid
+from .common import make_derivative as _make_derivative
+from .common import make_derivative2 as _make_derivative2
 from .common import make_general_poisson_solver, uniform_discretization
+
+# The `make_derivative?` methods are imported for backward compatibility. Their usage is
+# deprecated since 2023-12-06
 
 
 def _get_laplace_matrix_1d(bcs: Boundaries) -> Tuple[np.ndarray, np.ndarray]:
@@ -251,165 +256,6 @@ def _get_laplace_matrix(bcs: Boundaries) -> Tuple[np.ndarray, np.ndarray]:
         raise NotImplementedError(f"{dim:d}-dimensional Laplace matrix not implemented")
 
     return result
-
-
-def _make_derivative(
-    grid: CartesianGrid,
-    axis: int = 0,
-    method: Literal["central", "forward", "backward"] = "central",
-) -> OperatorType:
-    """make a derivative operator along a single axis using numba compilation
-
-    Args:
-        grid (:class:`~pde.grids.cartesian.CartesianGrid`):
-            The grid for which the operator is created
-        axis (int):
-            The axis along which the derivative will be taken
-        method (str):
-            The method for calculating the derivative. Possible values are
-            'central', 'forward', and 'backward'.
-
-    Returns:
-        A function that can be applied to an full array of values including those at
-        ghost cells. The result will be an array of the same shape containing the actual
-        derivatives at the valid (interior) grid points.
-    """
-    if method not in {"central", "forward", "backward"}:
-        raise ValueError(f"Unknown derivative type `{method}`")
-
-    shape = grid.shape
-    dim = len(shape)
-    dx = grid.discretization[axis]
-
-    if axis == 0:
-        di, dj, dk = 1, 0, 0
-    elif axis == 1:
-        di, dj, dk = 0, 1, 0
-    elif axis == 2:
-        di, dj, dk = 0, 0, 1
-    else:
-        raise NotImplementedError(f"Derivative for {axis:d} dimensions")
-
-    if dim == 1:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 1d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                if method == "central":
-                    out[i - 1] = (arr[i + 1] - arr[i - 1]) / (2 * dx)
-                elif method == "forward":
-                    out[i - 1] = (arr[i + 1] - arr[i]) / dx
-                elif method == "backward":
-                    out[i - 1] = (arr[i] - arr[i - 1]) / dx
-
-    elif dim == 2:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 2d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                for j in range(1, shape[1] + 1):
-                    arr_l = arr[i - di, j - dj]
-                    arr_r = arr[i + di, j + dj]
-                    if method == "central":
-                        out[i - 1, j - 1] = (arr_r - arr_l) / (2 * dx)
-                    elif method == "forward":
-                        out[i - 1, j - 1] = (arr_r - arr[i, j]) / dx
-                    elif method == "backward":
-                        out[i - 1, j - 1] = (arr[i, j] - arr_l) / dx
-
-    elif dim == 3:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 3d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                for j in range(1, shape[1] + 1):
-                    for k in range(1, shape[2] + 1):
-                        arr_l = arr[i - di, j - dj, k - dk]
-                        arr_r = arr[i + di, j + dj, k + dk]
-                        if method == "central":
-                            out[i - 1, j - 1, k - 1] = (arr_r - arr_l) / (2 * dx)
-                        elif method == "forward":
-                            out[i - 1, j - 1, k - 1] = (arr_r - arr[i, j, k]) / dx
-                        elif method == "backward":
-                            out[i - 1, j - 1, k - 1] = (arr[i, j, k] - arr_l) / dx
-
-    else:
-        raise NotImplementedError(
-            f"Numba derivative operator not implemented for {dim:d} dimensions"
-        )
-
-    return diff  # type: ignore
-
-
-def _make_derivative2(grid: CartesianGrid, axis: int = 0) -> OperatorType:
-    """make a second-order derivative operator along a single axis
-
-    Args:
-        grid (:class:`~pde.grids.cartesian.CartesianGrid`):
-            The grid for which the operator is created
-        axis (int):
-            The axis along which the derivative will be taken
-
-    Returns:
-        A function that can be applied to an full array of values including those at
-        ghost cells. The result will be an array of the same shape containing the actual
-        derivatives at the valid (interior) grid points.
-    """
-    shape = grid.shape
-    dim = len(shape)
-    scale = 1 / grid.discretization[axis] ** 2
-
-    if axis == 0:
-        di, dj, dk = 1, 0, 0
-    elif axis == 1:
-        di, dj, dk = 0, 1, 0
-    elif axis == 2:
-        di, dj, dk = 0, 0, 1
-    else:
-        raise NotImplementedError(f"Derivative for {axis:d} dimensions")
-
-    if dim == 1:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 1d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                out[i - 1] = (arr[i + 1] - 2 * arr[i] + arr[i - 1]) * scale
-
-    elif dim == 2:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 2d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                for j in range(1, shape[1] + 1):
-                    arr_l = arr[i - di, j - dj]
-                    arr_r = arr[i + di, j + dj]
-                    out[i - 1, j - 1] = (arr_r - 2 * arr[i, j] + arr_l) * scale
-
-    elif dim == 3:
-
-        @jit
-        def diff(arr: np.ndarray, out: np.ndarray) -> None:
-            """calculate derivative of 3d array `arr`"""
-            for i in range(1, shape[0] + 1):
-                for j in range(1, shape[1] + 1):
-                    for k in range(1, shape[2] + 1):
-                        arr_l = arr[i - di, j - dj, k - dk]
-                        arr_r = arr[i + di, j + dj, k + dk]
-                        out[i - 1, j - 1, k - 1] = (
-                            arr_r - 2 * arr[i, j, k] + arr_l
-                        ) * scale
-
-    else:
-        raise NotImplementedError(
-            f"Numba derivative operator not implemented for {dim:d} dimensions"
-        )
-
-    return diff  # type: ignore
 
 
 def _make_laplace_scipy_nd(grid: CartesianGrid) -> OperatorType:

--- a/pde/grids/operators/common.py
+++ b/pde/grids/operators/common.py
@@ -10,14 +10,185 @@ from typing import Callable, Literal, Optional
 
 import numpy as np
 
+from ...tools.numba import jit
 from ...tools.typing import OperatorType
 from ..base import GridBase
 
 logger = logging.getLogger(__name__)
 
 
+def make_derivative(
+    grid: GridBase,
+    axis: int = 0,
+    method: Literal["central", "forward", "backward"] = "central",
+) -> OperatorType:
+    """make a derivative operator along a single axis using numba compilation
+
+    Args:
+        grid (:class:`~pde.grids.base.GridBase`):
+            The grid for which the operator is created
+        axis (int):
+            The axis along which the derivative will be taken
+        method (str):
+            The method for calculating the derivative. Possible values are
+            'central', 'forward', and 'backward'.
+
+    Returns:
+        A function that can be applied to an full array of values including those at
+        ghost cells. The result will be an array of the same shape containing the actual
+        derivatives at the valid (interior) grid points.
+    """
+    if method not in {"central", "forward", "backward"}:
+        raise ValueError(f"Unknown derivative type `{method}`")
+
+    shape = grid.shape
+    num_axes = len(shape)
+    dx = grid.discretization[axis]
+
+    if axis == 0:
+        di, dj, dk = 1, 0, 0
+    elif axis == 1:
+        di, dj, dk = 0, 1, 0
+    elif axis == 2:
+        di, dj, dk = 0, 0, 1
+    else:
+        raise NotImplementedError(f"Derivative for {axis:d} dimensions")
+
+    if num_axes == 1:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 1d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                if method == "central":
+                    out[i - 1] = (arr[i + 1] - arr[i - 1]) / (2 * dx)
+                elif method == "forward":
+                    out[i - 1] = (arr[i + 1] - arr[i]) / dx
+                elif method == "backward":
+                    out[i - 1] = (arr[i] - arr[i - 1]) / dx
+
+    elif num_axes == 2:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 2d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                for j in range(1, shape[1] + 1):
+                    arr_l = arr[i - di, j - dj]
+                    arr_r = arr[i + di, j + dj]
+                    if method == "central":
+                        out[i - 1, j - 1] = (arr_r - arr_l) / (2 * dx)
+                    elif method == "forward":
+                        out[i - 1, j - 1] = (arr_r - arr[i, j]) / dx
+                    elif method == "backward":
+                        out[i - 1, j - 1] = (arr[i, j] - arr_l) / dx
+
+    elif num_axes == 3:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 3d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                for j in range(1, shape[1] + 1):
+                    for k in range(1, shape[2] + 1):
+                        arr_l = arr[i - di, j - dj, k - dk]
+                        arr_r = arr[i + di, j + dj, k + dk]
+                        if method == "central":
+                            out[i - 1, j - 1, k - 1] = (arr_r - arr_l) / (2 * dx)
+                        elif method == "forward":
+                            out[i - 1, j - 1, k - 1] = (arr_r - arr[i, j, k]) / dx
+                        elif method == "backward":
+                            out[i - 1, j - 1, k - 1] = (arr[i, j, k] - arr_l) / dx
+
+    else:
+        raise NotImplementedError(
+            f"Numba derivative operator not implemented for {num_axes:d} axes"
+        )
+
+    return diff  # type: ignore
+
+
+def make_derivative2(grid: GridBase, axis: int = 0) -> OperatorType:
+    """make a second-order derivative operator along a single axis
+
+    Args:
+        grid (:class:`~pde.grids.base.GridBase`):
+            The grid for which the operator is created
+        axis (int):
+            The axis along which the derivative will be taken
+
+    Returns:
+        A function that can be applied to an full array of values including those at
+        ghost cells. The result will be an array of the same shape containing the actual
+        derivatives at the valid (interior) grid points.
+    """
+    shape = grid.shape
+    num_axes = len(shape)
+    scale = 1 / grid.discretization[axis] ** 2
+
+    if axis == 0:
+        di, dj, dk = 1, 0, 0
+    elif axis == 1:
+        di, dj, dk = 0, 1, 0
+    elif axis == 2:
+        di, dj, dk = 0, 0, 1
+    else:
+        raise NotImplementedError(f"Derivative for {axis:d} dimensions")
+
+    if num_axes == 1:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 1d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                out[i - 1] = (arr[i + 1] - 2 * arr[i] + arr[i - 1]) * scale
+
+    elif num_axes == 2:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 2d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                for j in range(1, shape[1] + 1):
+                    arr_l = arr[i - di, j - dj]
+                    arr_r = arr[i + di, j + dj]
+                    out[i - 1, j - 1] = (arr_r - 2 * arr[i, j] + arr_l) * scale
+
+    elif num_axes == 3:
+
+        @jit
+        def diff(arr: np.ndarray, out: np.ndarray) -> None:
+            """calculate derivative of 3d array `arr`"""
+            for i in range(1, shape[0] + 1):
+                for j in range(1, shape[1] + 1):
+                    for k in range(1, shape[2] + 1):
+                        arr_l = arr[i - di, j - dj, k - dk]
+                        arr_r = arr[i + di, j + dj, k + dk]
+                        out[i - 1, j - 1, k - 1] = (
+                            arr_r - 2 * arr[i, j, k] + arr_l
+                        ) * scale
+
+    else:
+        raise NotImplementedError(
+            f"Numba derivative operator not implemented for {num_axes:d} axes"
+        )
+
+    return diff  # type: ignore
+
+
 def uniform_discretization(grid: GridBase) -> float:
-    """returns the uniform discretization or raises RuntimeError"""
+    """returns the uniform discretization or raises RuntimeError
+
+    Args:
+        grid (:class:`~pde.grids.base.GridBase`):
+            The grid whose discretization is tested
+
+    Raises:
+        `RuntimeError` if discretization is different between different axes
+
+    Returns:
+        float: the common discretization of all axes
+    """
     dx_mean = np.mean(grid.discretization)
     if np.allclose(grid.discretization, dx_mean):
         return float(dx_mean)
@@ -37,9 +208,8 @@ def make_laplace_from_matrix(
             Constant part representing the boundary conditions of the Laplace operator
 
     Returns:
-        A function that can be applied to an array of values to obtain the
-        solution to Poisson's equation where the array is used as the right hand
-        side
+        A function that can be applied to an array of values to obtain the result of
+        applying the linear operator `matrix` and the offset given by `vector`.
     """
     mat = matrix.tocsc()
     vec = vector.toarray()[:, 0]
@@ -71,9 +241,8 @@ def make_general_poisson_solver(
             The chosen method for implementing the operator
 
     Returns:
-        A function that can be applied to an array of values to obtain the
-        solution to Poisson's equation where the array is used as the right hand
-        side
+        A function that can be applied to an array of values to obtain the solution to
+        Poisson's equation where the array is used as the right hand side
     """
     from scipy import sparse
 

--- a/tests/grids/operators/test_cartesian_operators.py
+++ b/tests/grids/operators/test_cartesian_operators.py
@@ -322,46 +322,6 @@ def test_2nd_order_bc(rng):
     field.laplace([{"value": "sin(y)"}, {"value": "x"}])
 
 
-@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2)])
-def test_make_derivative(ndim, axis, rng):
-    """test the _make_derivative function"""
-    periodic = random.choice([True, False])
-    grid = CartesianGrid([[0, 6 * np.pi]] * ndim, 16, periodic=periodic)
-    field = ScalarField.random_harmonic(grid, modes=1, axis_combination=np.add, rng=rng)
-
-    bcs = grid.get_boundary_conditions("auto_periodic_neumann")
-    grad = field.gradient(bcs)
-    for method in ["central", "forward", "backward"]:
-        msg = f"method={method}, periodic={periodic}"
-        diff = ops._make_derivative(grid, axis=axis, method=method)
-        res = field.copy()
-        res.data[:] = 0
-        field.set_ghost_cells(bcs)
-        diff(field._data_full, out=res.data)
-        np.testing.assert_allclose(
-            grad.data[axis], res.data, atol=0.1, rtol=0.1, err_msg=msg
-        )
-
-
-@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2)])
-def test_make_derivative2(ndim, axis, rng):
-    """test the _make_derivative2 function"""
-    periodic = random.choice([True, False])
-    grid = CartesianGrid([[0, 6 * np.pi]] * ndim, 16, periodic=periodic)
-    field = ScalarField.random_harmonic(grid, modes=1, axis_combination=np.add, rng=rng)
-
-    bcs = grid.get_boundary_conditions("auto_periodic_neumann")
-    grad = field.gradient(bcs)[axis]
-    grad2 = grad.gradient(bcs)[axis]
-
-    diff = ops._make_derivative2(grid, axis=axis)
-    res = field.copy()
-    res.data[:] = 0
-    field.set_ghost_cells(bcs)
-    diff(field._data_full, out=res.data)
-    np.testing.assert_allclose(grad2.data, res.data, atol=0.1, rtol=0.1)
-
-
 @pytest.mark.parametrize("ndim", [1, 2, 3])
 def test_laplace_matrix(ndim, rng):
     """test laplace operator implemented using matrix multiplication"""

--- a/tests/grids/operators/test_common_operators.py
+++ b/tests/grids/operators/test_common_operators.py
@@ -1,0 +1,51 @@
+"""
+.. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
+"""
+
+import random
+
+import numpy as np
+import pytest
+
+from pde import CartesianGrid, ScalarField
+from pde.grids.operators import cartesian as ops
+
+
+@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2)])
+def test_make_derivative(ndim, axis, rng):
+    """test the _make_derivative function"""
+    periodic = random.choice([True, False])
+    grid = CartesianGrid([[0, 6 * np.pi]] * ndim, 16, periodic=periodic)
+    field = ScalarField.random_harmonic(grid, modes=1, axis_combination=np.add, rng=rng)
+
+    bcs = grid.get_boundary_conditions("auto_periodic_neumann")
+    grad = field.gradient(bcs)
+    for method in ["central", "forward", "backward"]:
+        msg = f"method={method}, periodic={periodic}"
+        diff = ops._make_derivative(grid, axis=axis, method=method)
+        res = field.copy()
+        res.data[:] = 0
+        field.set_ghost_cells(bcs)
+        diff(field._data_full, out=res.data)
+        np.testing.assert_allclose(
+            grad.data[axis], res.data, atol=0.1, rtol=0.1, err_msg=msg
+        )
+
+
+@pytest.mark.parametrize("ndim,axis", [(1, 0), (2, 0), (2, 1), (3, 0), (3, 1), (3, 2)])
+def test_make_derivative2(ndim, axis, rng):
+    """test the _make_derivative2 function"""
+    periodic = random.choice([True, False])
+    grid = CartesianGrid([[0, 6 * np.pi]] * ndim, 16, periodic=periodic)
+    field = ScalarField.random_harmonic(grid, modes=1, axis_combination=np.add, rng=rng)
+
+    bcs = grid.get_boundary_conditions("auto_periodic_neumann")
+    grad = field.gradient(bcs)[axis]
+    grad2 = grad.gradient(bcs)[axis]
+
+    diff = ops._make_derivative2(grid, axis=axis)
+    res = field.copy()
+    res.data[:] = 0
+    field.set_ghost_cells(bcs)
+    diff(field._data_full, out=res.data)
+    np.testing.assert_allclose(grad2.data, res.data, atol=0.1, rtol=0.1)


### PR DESCRIPTION
Also moved the methods to the `common` module in the `pde.grids.operators` package and adjusted their signature such that they can take any grid.