### PR TITLE
Allow using cartesian coordinates in (some) expressions

### DIFF
--- a/docs/source/manual/advanced_usage.rst
+++ b/docs/source/manual/advanced_usage.rst
@@ -181,6 +181,9 @@ field is defined on a two-dimensional Cartesian grid, the variables :code:`x` an
 :code:`y` denote the local coordinates. To initialize a step profile in the
 :math:`x`-direction, one can use either :code:`(x > 5)` or :code:`heaviside(x - 5, 0.5)`,
 where the second argument denotes the returned value in case the first argument is `0`.
+For convenience, Cartesian coordinates are also available when using curvilinear grids.
+The respective coordinate values at a point can be acccessed using :code:`cartesian[i]`,
+where :code:`i` is an index, e.g., `i=0` for the first axis (normally the x-axis).
 Finally, expressions for equations in :class:`~pde.pdes.pde.PDE` can explicitely depend
 on time, which is denoted by the variable :code:`t`.
 

--- a/pde/fields/scalar.py
+++ b/pde/fields/scalar.py
@@ -71,6 +71,15 @@ class ScalarField(DataFieldBase):
         """
         from ..tools.expressions import ScalarExpression
 
+        if "cartesian" in str(expression):
+            # support Cartesian coordinates via a special constant
+            if consts is None:
+                consts = {}
+            if "cartesian" not in consts:
+                coords_cart = grid.point_to_cartesian(grid.cell_coords)
+                consts["cartesian"] = np.moveaxis(coords_cart, -1, 0)
+            assert "cartesian" in consts
+
         # parse the expression
         expr = ScalarExpression(
             expression=expression,
@@ -78,6 +87,7 @@ class ScalarField(DataFieldBase):
             user_funcs=user_funcs,
             consts=consts,
             repl=grid.c._axes_alt_repl,
+            allow_indexed=True,
         )
         # obtain the coordinates of the grid points
         points = [grid.cell_coords[..., i] for i in range(grid.num_axes)]

--- a/pde/fields/tensorial.py
+++ b/pde/fields/tensorial.py
@@ -89,6 +89,15 @@ class Tensor2Field(DataFieldBase):
                 f"tensor components of the coordinates {axes_names}."
             )
 
+        if any("cartesian" in str(expression) for expression in expressions):
+            # support Cartesian coordinates via a special constant
+            if consts is None:
+                consts = {}
+            if "cartesian" not in consts:
+                coords_cart = grid.point_to_cartesian(grid.cell_coords)
+                consts["cartesian"] = np.moveaxis(coords_cart, -1, 0)
+            assert "cartesian" in consts
+
         # obtain the coordinates of the grid points
         points = [grid.cell_coords[..., i] for i in range(grid.num_axes)]
 
@@ -102,6 +111,7 @@ class Tensor2Field(DataFieldBase):
                     user_funcs=user_funcs,
                     consts=consts,
                     repl=grid.c._axes_alt_repl,
+                    allow_indexed=True,
                 )
                 values = np.broadcast_to(expr(*points), grid.shape)
                 data[i][j] = values

--- a/pde/fields/vectorial.py
+++ b/pde/fields/vectorial.py
@@ -127,6 +127,15 @@ class VectorField(DataFieldBase):
                 f"Expected {grid.dim} expressions for the coordinates {axes_names}."
             )
 
+        if any("cartesian" in str(expression) for expression in expressions):
+            # support Cartesian coordinates via a special constant
+            if consts is None:
+                consts = {}
+            if "cartesian" not in consts:
+                coords_cart = grid.point_to_cartesian(grid.cell_coords)
+                consts["cartesian"] = np.moveaxis(coords_cart, -1, 0)
+            assert "cartesian" in consts
+
         # obtain the coordinates of the grid points
         points = [grid.cell_coords[..., i] for i in range(grid.num_axes)]
 
@@ -139,6 +148,7 @@ class VectorField(DataFieldBase):
                 user_funcs=user_funcs,
                 consts=consts,
                 repl=grid.c._axes_alt_repl,
+                allow_indexed=True,
             )
             values = np.broadcast_to(expr(*points), grid.shape)
             data.append(values)

--- a/pde/tools/expressions.py
+++ b/pde/tools/expressions.py
@@ -346,7 +346,7 @@ class ExpressionBase(metaclass=ABCMeta):
                     found.add(arg)
                     break
 
-        args = set(args) - found
+        args = set(args) - found - set(self.consts)
         if len(args) > 0:
             raise RuntimeError(
                 f"Arguments {args} were not defined in expression signature {signature}"

--- a/tests/fields/test_scalar_fields.py
+++ b/tests/fields/test_scalar_fields.py
@@ -241,6 +241,9 @@ def test_from_expression():
     sf = ScalarField.from_expression(grid, "c", consts={"c": [0.25, 0.75]})
     np.testing.assert_allclose(sf.data, [[0.25, 0.75]])
 
+    sf = ScalarField.from_expression(grid, "cartesian[0] * cartesian[1]")
+    np.testing.assert_allclose(sf.data, [[0.25, 0.75]])
+
 
 def test_from_image(tmp_path, rng):
     from matplotlib.pyplot import imsave

--- a/tests/fields/test_tensorial_fields.py
+++ b/tests/fields/test_tensorial_fields.py
@@ -216,6 +216,11 @@ def test_from_expressions():
     np.testing.assert_allclose(tf.data[1, 0], xs**2)
     np.testing.assert_allclose(tf.data[1, 1], xs * ys)
 
+    tf2 = Tensor2Field.from_expression(grid, [[1, 1], ["cartesian[0]**2", "x * y"]])
+    np.testing.assert_array_equal(tf.data, tf2.data)
+    tf2 = Tensor2Field.from_expression(grid, [[1, 1], ["x**2", "x * cartesian[1]"]])
+    np.testing.assert_array_equal(tf.data, tf2.data)
+
     # corner case
     with pytest.raises(ValueError):
         Tensor2Field.from_expression(grid, "xy")

--- a/tests/fields/test_vectorial_fields.py
+++ b/tests/fields/test_vectorial_fields.py
@@ -176,6 +176,11 @@ def test_from_expressions():
     np.testing.assert_allclose(vf.data[0], xs**2)
     np.testing.assert_allclose(vf.data[1], xs * ys)
 
+    vf2 = VectorField.from_expression(grid, ["cartesian[0]**2", "x * y"])
+    np.testing.assert_array_equal(vf.data, vf2.data)
+    vf3 = VectorField.from_expression(grid, ["x**2", "x * cartesian[1]"])
+    np.testing.assert_array_equal(vf.data, vf3.data)
+
     # corner case
     vf = VectorField.from_expression(grid, ["1", "x * y"])
     np.testing.assert_allclose(vf.data[0], 1)

--- a/tests/grids/test_coordinates.py
+++ b/tests/grids/test_coordinates.py
@@ -37,6 +37,21 @@ def test_basic_coordinates(c, rng):
 
 
 @pytest.mark.parametrize("c", iter_coordinates())
+def test_basic_coordinate_arrays(c, rng):
+    """Test conversion of coordinates given in arrays."""
+    x = rng.uniform(size=(7, c.dim))
+    p = c.pos_from_cart(x)
+    assert p.shape == (7, c.dim)
+    np.testing.assert_allclose(c.pos_to_cart(p), x)
+
+    xT = x.T
+    assert xT.shape == (c.dim, 7)
+    pT = c.pos_from_cart(xT, axis=0)
+    np.testing.assert_allclose(pT, p.T)
+    np.testing.assert_allclose(c.pos_to_cart(pT, axis=0), xT)
+
+
+@pytest.mark.parametrize("c", iter_coordinates())
 def test_coordinate_volume_factors(c, rng):
     """Test basic coordinate properties."""
     p1 = c.pos_from_cart(rng.uniform(-1, 1, size=c.dim))


### PR DESCRIPTION
This is implemented by special constants with are added to expressions when "cartesian" is part of the expression. We also allow indexed variables in expressions to enabel this feature. This should not break any existing code.