### PR TITLE
Deprecated `Parameterized` class

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -240,7 +240,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
     "modelrunner": ("https://py-modelrunner.readthedocs.io/en/latest", None),
     "napari": ("https://napari.org/", None),
-    "numba": ("https://numba.pydata.org/numba-doc/latest/", None),
+    "numba": ("https://numba.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "python": ("https://docs.python.org/3/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),

--- a/pde/tools/parameters.py
+++ b/pde/tools/parameters.py
@@ -176,6 +176,10 @@ class Parameterized:
                 :meth:`~Parameterized.get_parameters` or displayed by calling
                 :meth:`~Parameterized.show_parameters`.
         """
+        # deprecated on 2024-08-15
+        warnings.warn(
+            "`Parameterized` has been moved to `py-modelrunner`", DeprecationWarning
+        )
         # set logger if this has not happened, yet
         if not hasattr(self, "_logger"):
             self._logger = logging.getLogger(self.__class__.__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,8 @@
 [project]
 name = "py-pde"
 description = "Python package for solving partial differential equations"
-authors = [
-    {name = "David Zwicker", email="david.zwicker@ds.mpg.de"}
-]
-license = {text = "MIT"}
+authors = [{ name = "David Zwicker", email = "david.zwicker@ds.mpg.de" }]
+license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.9,<3.13"
 dynamic = ["version"]
@@ -27,7 +25,14 @@ classifiers = [
 ]
 
 # Requirements for setuptools
-dependencies = ["matplotlib>=3.1", "numba>=0.59", "numpy>=1.22", "scipy>=1.10", "sympy>=1.9", "tqdm>=4.66"]
+dependencies = [
+    "matplotlib>=3.1",
+    "numba>=0.59",
+    "numpy>=1.22",
+    "scipy>=1.10",
+    "sympy>=1.9",
+    "tqdm>=4.66",
+]
 
 [project.optional-dependencies]
 io = ["h5py>=2.10", "pandas>=2", "ffmpeg-python>=0.2"]
@@ -40,15 +45,12 @@ documentation = "http://py-pde.readthedocs.io"
 repository = "https://github.com/zwicker-group/py-pde"
 
 [build-system]
-requires = [
-    "setuptools>=61",
-    "setuptools_scm[toml]>=6.2",
-]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
-zip-safe = false  # required for mypy to find the py.typed file
+zip-safe = false            # required for mypy to find the py.typed file
 
 [tool.setuptools.packages.find]
 include = ["pde*"]
@@ -65,7 +67,14 @@ exclude = "scripts/templates"
 profile = "black"
 src_paths = ["pde", "examples", "scripts", "tests"]
 known_self = ["pde", "fixtures"]
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "SELF", "LOCALFOLDER"]
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "FIRSTPARTY",
+    "SELF",
+    "LOCALFOLDER",
+]
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from pde.tools.numba import random_seed
 @pytest.fixture(scope="function", autouse=True)
 def setup_and_teardown():
     """Helper function adjusting environment before and after tests."""
+    # ensure we use the Agg backend, so figures are not displayed
+    plt.switch_backend("agg")
     # raise all underflow errors
     np.seterr(all="raise", under="ignore")
 


### PR DESCRIPTION
* Deprecate the Parameterized class (has been moved to `py-modelrunner)
* The numba documentation link has been updated to point to the stable version.