### PR TITLE
feat: Deprecate preserve_scalars method in misc.py

### DIFF
--- a/pde/tools/misc.py
+++ b/pde/tools/misc.py
@@ -26,6 +26,7 @@ import functools
 import importlib
 import json
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Callable, TypeVar
 
@@ -80,6 +81,8 @@ def preserve_scalars(method: TFunc) -> TFunc:
     Returns:
         The decorated method
     """
+    # deprecated on 2024-08-21
+    warnings.warn("Method deprecated", DeprecationWarning)
 
     @functools.wraps(method)
     def wrapper(self, *args):

--- a/tests/grids/operators/test_cartesian_operators.py
+++ b/tests/grids/operators/test_cartesian_operators.py
@@ -346,7 +346,7 @@ def test_laplace_matrix(ndim, rng):
 
 
 @pytest.mark.parametrize(
-    "grid", [UnitGrid([12]), CartesianGrid([[0, 1], [4, 5.5]], 8), UnitGrid([3, 3, 3])]
+    "grid", [UnitGrid([12]), CartesianGrid([(0, 1), (4, 5.5)], 8), UnitGrid([3, 3, 3])]
 )
 @pytest.mark.parametrize("bc_val", ["auto_periodic_neumann", {"value": "sin(x)"}])
 def test_poisson_solver_cartesian(grid, bc_val, rng):


### PR DESCRIPTION
The `preserve_scalars` method in `misc.py` has been deprecated with a warning message.