### PR TITLE
Disable multithreading on HPC by default

### DIFF
--- a/docs/source/manual/advanced_usage.rst
+++ b/docs/source/manual/advanced_usage.rst
@@ -486,7 +486,7 @@ Here, we use the implementation shipped with `py-pde`, which sets some default
 values.
 However, we could have also used the usual numba implementation.
 It is important that the implementation of the evolution rate only uses python
-constructs that numba can compile.  
+constructs that numba can compile.
 
 One advantage of the numba compiled implementation is that we can now use loops,
 which will be much faster than their python equivalents.
@@ -529,7 +529,7 @@ Here, we extract the total number of elements in the state using its
 :attr:`size` attribute and we obtain the dimensionality of the space from the
 grid attribute :attr:`dim`.
 Note that we access numpy arrays using their :attr:`flat` attribute to provide
-an implementation that works for all dimensions.     
+an implementation that works for all dimensions.
 
 
 .. _configuration:
@@ -547,13 +547,16 @@ Here is a list of all configuration options that can be adjusted in the package:
 
 .. tip::
 
-    To disable parallel computing in the package, the following code could be added to
-    the start of the script:
+    To disable parallel computing via multithreading in the package, the following code
+    could be added to the start of the script:
 
 
     .. code-block:: python
 
         from pde import config
-        config["numba.multithreading"] = False
+        config["numba.multithreading"] = "never"
 
         # actual code using py-pde
+
+    The default value `only_local` already disables multithreading when the package
+    detects it is run in an HPC environment.

--- a/pde/tools/config.py
+++ b/pde/tools/config.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import importlib
+import os
 import re
 import subprocess as sp
 import sys
@@ -81,11 +82,13 @@ DEFAULT_CONFIG: list[Parameter] = [
     ),
     Parameter(
         "numba.multithreading",
-        True,
-        bool,
+        "only_local",
+        str,
         "Determines whether multiple threads are used in numba-compiled code. Enabling "
         "this option accelerates a small subset of operators applied to fields defined "
-        "on large grids.",
+        "on large grids. Possible options are 'never' (disable multithreading), 'local' "
+        "(disable on HPC hardware), and 'always' (enable if number of grid points "
+        "exceeds `numba.multithreading_threshold`)",
     ),
     Parameter(
         "numba.multithreading_threshold",
@@ -130,10 +133,21 @@ class Config(collections.UserDict):
         else:
             return parameter
 
+    def _convert_value(self, key: str, value):
+        """Helper function converting certain values."""
+        if key == "numba.multithreading" and isinstance(value, bool):
+            value = "always" if value else "never"
+            warnings.warn(
+                "Boolean options are deprecated for `numba.multithreading`. Use "
+                f"config['numba.multithreading'] = '{value}' instead.",
+                DeprecationWarning,
+            )
+        return value
+
     def __setitem__(self, key: str, value):
         """Update item `key` with `value`"""
         if self.mode == "insert":
-            self.data[key] = value
+            self.data[key] = self._convert_value(key, value)
 
         elif self.mode == "update":
             try:
@@ -142,7 +156,7 @@ class Config(collections.UserDict):
                 raise KeyError(
                     f"{key} is not present and config is not in `insert` mode"
                 ) from err
-            self.data[key] = value
+            self.data[key] = self._convert_value(key, value)
 
         elif self.mode == "locked":
             raise RuntimeError("Configuration is locked")
@@ -185,6 +199,37 @@ class Config(collections.UserDict):
         yield  # return to caller
         # restore old configuration
         self.data = data_initial
+
+    def use_multithreading(self) -> bool:
+        """Determine whether multithreading should be used in numba-compiled code.
+
+        This method checks the configuration setting for `numba.multithreading` and
+        determines whether multithreading should be enabled based on the value of this
+        setting. The possible values for `numba.multithreading` are:
+        - 'always': Multithreading is always enabled.
+        - 'never': Multithreading is never enabled.
+        - 'only_local': Multithreading is enabled only if the code is not running in a
+        high-performance computing (HPC) environment.
+
+        Returns:
+            bool: True if multithreading should be enabled, False otherwise.
+
+        Raises:
+            ValueError: If the `numba.multithreading` setting is not one of the expected
+            values ('always', 'never', 'only_local').
+        """
+        setting = self["numba.multithreading"]
+        if setting == "always":
+            return True
+        elif setting == "never":
+            return False
+        elif setting == "only_local":
+            return not is_hpc_environment()
+        else:
+            raise ValueError(
+                "Parameter `numba.multithreading` must be in {'always', 'never', "
+                f"'only_local'}}, not `{setting}`"
+            )
 
 
 def get_package_versions(
@@ -278,6 +323,16 @@ def get_ffmpeg_version() -> str | None:
     return None
 
 
+def is_hpc_environment() -> bool:
+    """Check whether the code is running in a high-performance computing environment.
+
+    Returns:
+        bool: True if running in an HPC environment, False otherwise.
+    """
+    hpc_env_vars = ["SLURM_JOB_ID", "PBS_JOBID", "LSB_JOBID"]
+    return any(var in os.environ for var in hpc_env_vars)
+
+
 def environment() -> dict[str, Any]:
     """Obtain information about the compute environment.
 
@@ -297,7 +352,9 @@ def environment() -> dict[str, Any]:
     result: dict[str, Any] = {}
     result["package version"] = package_version
     result["python version"] = sys.version
-    result["platform"] = sys.platform
+
+    # check the compute environment
+    result["environment"] = {"platform": sys.platform, "is_hpc": is_hpc_environment()}
 
     # add ffmpeg version if available
     ffmpeg_version = get_ffmpeg_version()

--- a/pde/tools/numba.py
+++ b/pde/tools/numba.py
@@ -169,7 +169,7 @@ def jit(function: TFunc, signature=None, parallel: bool = False, **kwargs) -> TF
         kwargs.setdefault("fastmath", config["numba.fastmath"])
     kwargs.setdefault("debug", config["numba.debug"])
     # make sure parallel numba is only enabled in restricted cases
-    kwargs["parallel"] = parallel and config["numba.multithreading"]
+    kwargs["parallel"] = parallel and config.use_multithreading()
 
     # log some details
     logger = logging.getLogger(__name__)

--- a/scripts/performance_laplace.py
+++ b/scripts/performance_laplace.py
@@ -17,7 +17,7 @@ from pde.grids.operators.cartesian import _make_laplace_numba_2d
 from pde.tools.misc import estimate_computation_speed
 from pde.tools.numba import jit
 
-config["numba.multithreading"] = False
+config["numba.multithreading"] = "never"  # disable multithreading for better comparison
 
 
 def custom_laplace_2d_periodic(shape, dx=1):

--- a/scripts/show_environment.py
+++ b/scripts/show_environment.py
@@ -19,5 +19,5 @@ for category, data in environment().items():
         for key, value in data.items():
             print(f"    {key}: {value}")
     else:
-        data_formatted = data.replace("\n", "\n    ")
+        data_formatted = str(data).replace("\n", "\n    ")
         print(f"{category}: {data_formatted}")

--- a/tests/tools/test_config.py
+++ b/tests/tools/test_config.py
@@ -33,6 +33,8 @@ def test_config_modes():
     assert c["numba.multithreading_threshold"] == 0
     c["new_value"] = "value"
     assert c["new_value"] == "value"
+    c.update({"new_value2": "value2"})
+    assert c["new_value2"] == "value2"
     del c["new_value"]
     with pytest.raises(KeyError):
         c["new_value"]
@@ -45,6 +47,8 @@ def test_config_modes():
 
     with pytest.raises(KeyError):
         c["new_value"] = "value"
+    with pytest.raises(KeyError):
+        c.update({"new_value": "value"})
     with pytest.raises(RuntimeError):
         del c["numba.multithreading_threshold"]
     with pytest.raises(KeyError):
@@ -54,6 +58,8 @@ def test_config_modes():
     assert c["numba.multithreading_threshold"] > 0
     with pytest.raises(RuntimeError):
         c["numba.multithreading_threshold"] = 0
+    with pytest.raises(RuntimeError):
+        c.update({"numba.multithreading_threshold": 0})
     with pytest.raises(RuntimeError):
         c["new_value"] = "value"
     with pytest.raises(RuntimeError):
@@ -65,6 +71,8 @@ def test_config_modes():
     assert c["numba.multithreading_threshold"] > 0
     with pytest.raises(ValueError):
         c["numba.multithreading_threshold"] = 0
+    with pytest.raises(ValueError):
+        c.update({"numba.multithreading_threshold": 0})
     with pytest.raises(RuntimeError):
         del c["numba.multithreading_threshold"]
 
@@ -84,6 +92,17 @@ def test_config_contexts():
         assert c["numba.multithreading_threshold"] == 0
 
     assert c["numba.multithreading_threshold"] > 0
+
+
+def test_config_special_values():
+    """Test configuration system running in different modes."""
+    c = Config()
+    c["numba.multithreading"] = True
+    assert c["numba.multithreading"] == "always"
+    assert c.use_multithreading()
+    c["numba.multithreading"] = False
+    assert c["numba.multithreading"] == "never"
+    assert not c.use_multithreading()
 
 
 def test_packages_from_requirements():


### PR DESCRIPTION
To support this, we refactored numba multithreading configuration and updated the parameter type, enhanced handling, and improved environment checks.

Closes #635