### PR TITLE
Add a simple way to check whether a backend is available

### DIFF
--- a/docs/source/manual/performance.rst
+++ b/docs/source/manual/performance.rst
@@ -64,12 +64,7 @@ costly.
 For small systems, it can thus be advisable to use the `numpy` backend.
 Since some backends rely on optional packages, the function
 :func:`~pde.backends.registry.available_backends` lists the backends that can actually
-be used in the current environment:
-
-.. code-block:: python
-
-    print(pde.available_backends())
-
+be used in the current environment.
 In contrast, :func:`~pde.backends.registry.registered_backends` lists all backends that
 the package knows about, including those whose packages are not installed.
 

--- a/docs/source/manual/performance.rst
+++ b/docs/source/manual/performance.rst
@@ -62,6 +62,16 @@ Here, compiled backends, like `numba` and `torch`, provide the fastest speed,
 particularly for larger systems, but they require an initial compilation, which can be
 costly.
 For small systems, it can thus be advisable to use the `numpy` backend.
+Since some backends rely on optional packages, the function
+:func:`~pde.backends.registry.available_backends` lists the backends that can actually
+be used in the current environment:
+
+.. code-block:: python
+
+    print(pde.available_backends())
+
+In contrast, :func:`~pde.backends.registry.registered_backends` lists all backends that
+the package knows about, including those whose packages are not installed.
 
 As a rule of thumb, simulations run faster when there are fewer degrees of freedom.
 In the case of partial differential equations, this often means using a coarser grid

--- a/pde/backends/__init__.py
+++ b/pde/backends/__init__.py
@@ -40,6 +40,7 @@ from pathlib import Path
 # load the registry, which manages all backends
 from .base import BackendBase
 from .registry import (
+    available_backends,
     backend_registry,
     get_backend,
     load_default_config,
@@ -48,23 +49,33 @@ from .registry import (
 
 # register backends without loading them
 BACKENDS_FOLDER = Path(__file__).parent
-backend_registry.register_package("numpy", "pde.backends.numpy")
+backend_registry.register_package("numpy", "pde.backends.numpy", requires=["numpy"])
 backend_registry.register_package(
     "numba",
     "pde.backends.numba",
     config=load_default_config(BACKENDS_FOLDER / "numba" / "config.py"),
+    requires=["numba"],
 )
-backend_registry.register_package("numba_mpi", "pde.backends.numba_mpi")
-backend_registry.register_package("scipy", "pde.backends.scipy")
+backend_registry.register_package(
+    "numba_mpi", "pde.backends.numba_mpi", requires=["numba", "numba_mpi"]
+)
+backend_registry.register_package("scipy", "pde.backends.scipy", requires=["scipy"])
 backend_registry.register_package(
     "jax",
     "pde.backends.jax",
     config=load_default_config(BACKENDS_FOLDER / "jax" / "config.py"),
+    requires=["jax"],
 )
 backend_registry.register_package(
     "torch",
     "pde.backends.torch",
     config=load_default_config(BACKENDS_FOLDER / "torch" / "config.py"),
+    requires=["torch"],
 )
 
-__all__ = ["BackendBase", "get_backend", "registered_backends"]
+__all__ = [
+    "BackendBase",
+    "available_backends",
+    "get_backend",
+    "registered_backends",
+]

--- a/pde/backends/registry.py
+++ b/pde/backends/registry.py
@@ -7,6 +7,7 @@
    load_default_config
    get_backend
    registered_backends
+   available_backends
 
 .. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
 """
@@ -20,6 +21,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .. import config as global_config
+from ..tools.misc import module_available
 from .base import _RESERVED_BACKEND_NAMES, BackendBase
 
 if TYPE_CHECKING:
@@ -44,6 +46,8 @@ class BackendRegistry:
 
     _packages: dict[str, str]
     """dict: backends whose packages have been registered"""
+    _requirements: dict[str, tuple[str, ...]]
+    """dict: python modules required by the backends whose packages are registered"""
     _classes: dict[str, type[BackendBase]]
     """dict: backends whose classes have been defined"""
     _backends: dict[str, BackendBase]
@@ -51,6 +55,7 @@ class BackendRegistry:
 
     def __init__(self):
         self._packages = {}
+        self._requirements = {}
         self._classes = {}
         self._backends = {}
 
@@ -60,6 +65,7 @@ class BackendRegistry:
         package_path: str,
         *,
         config: ConfigLike | Sequence[Parameter] | None = None,
+        requires: Sequence[str] = (),
     ) -> None:
         """Register a backend python package (without loading it yet)
 
@@ -70,6 +76,10 @@ class BackendRegistry:
                 Import path for the package
             config (list):
                 Configuration options for the package
+            requires (sequence of str):
+                Names of the python modules that need to be installed for this backend
+                to work. They are used by :meth:`BackendRegistry.is_available` to check
+                whether the backend can be used without importing it.
         """
         if name in _RESERVED_BACKEND_NAMES:
             _logger.warning("Reserved backend name `%s` should not be used.", name)
@@ -77,6 +87,7 @@ class BackendRegistry:
             msg = f"Cannot redefine backend `{name}`"
             raise RuntimeError(msg)
         self._packages[name] = package_path
+        self._requirements[name] = tuple(requires)
         with global_config.changed_mode(node="insert", leaf="insert"):
             if config is None:
                 global_config["backend"].create_node(name)
@@ -115,6 +126,32 @@ class BackendRegistry:
             else:
                 _logger.info("Reloading backend `%s`", backend.name)
         self._backends[backend.name] = backend
+
+    def is_available(self, name: str) -> bool:
+        """Check whether a backend can be used in the current environment.
+
+        The check is based on the python modules that were given as `requires` when the
+        backend was registered, so no backend is imported by this method.
+
+        Args:
+            name (str):
+                Name of the backend. Additional information given after a colon, e.g.,
+                in :code:`torch:cuda`, is ignored, so this method only checks whether
+                the backend itself could be loaded.
+
+        Returns:
+            bool: Whether the backend can be used. Backends that are not registered at
+            all are reported as being unavailable.
+        """
+        if name == "default":
+            name = global_config["default_backend"]
+        name = name.split(":", 1)[0]  # strip additional information from the name
+
+        if name in self._backends or name in self._classes:
+            return True  # backend has been loaded already, so it must be available
+        if name not in self._packages:
+            return False  # backend is not known at all
+        return all(module_available(module) for module in self._requirements[name])
 
     def _get_class(self, name: str) -> type[BackendBase]:
         """Get the class associated with a particular backend.
@@ -241,6 +278,8 @@ class BackendRegistry:
     def values(self) -> Iterator[BackendBase]:
         """Iterate over all backends that can be imported."""
         for name in self:
+            if not self.is_available(name):
+                continue
             with contextlib.suppress(ImportError):
                 yield self.get_backend(name)
 
@@ -323,3 +362,15 @@ def get_backend(
 def registered_backends() -> list[str]:
     """Returns all registered backends."""
     return list(backend_registry)
+
+
+def available_backends() -> list[str]:
+    """Returns all backends that can be used in the current environment.
+
+    In contrast to :func:`registered_backends`, this omits backends whose python
+    packages are not installed, e.g., the `torch` backend if :mod:`torch` is missing.
+
+    Returns:
+        list of str: The names of all backends that can be loaded
+    """
+    return [name for name in backend_registry if backend_registry.is_available(name)]

--- a/pde/pdes/base.py
+++ b/pde/pdes/base.py
@@ -383,7 +383,7 @@ class PDEBase(metaclass=ABCMeta):
         if use_mpi:
             candidates = ["numba_mpi"]
         else:
-            candidates = ["numba", "torch", "numpy"]
+            candidates = ["numba", "jax", "torch", "numpy"]
 
         # choose backend automatically by trial and error to see which one works
         for backend in candidates:

--- a/pde/pdes/base.py
+++ b/pde/pdes/base.py
@@ -397,7 +397,8 @@ class PDEBase(metaclass=ABCMeta):
             else:
                 break  # found a suitable backend
         else:
-            msg = "Could not select a suitable backend"
+            candidates_str = ", ".join(f"`{name}`" for name in candidates)
+            msg = f"Could not select a suitable backend from {candidates_str}"
             raise RuntimeError(msg)
         return get_backend(backend)
 

--- a/pde/pdes/base.py
+++ b/pde/pdes/base.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
-from ..backends import BackendBase, get_backend
+from ..backends import BackendBase, backend_registry, get_backend
 from ..fields import FieldCollection
 from ..fields.datafield_base import DataFieldBase
 
@@ -387,7 +387,9 @@ class PDEBase(metaclass=ABCMeta):
 
         # choose backend automatically by trial and error to see which one works
         for backend in candidates:
-            # TODO: Could first add a check whether module is available; Issue #762
+            if not backend_registry.is_available(backend):
+                self._logger.info("Backend `%s` is not available", backend)
+                continue
             try:
                 self.make_pde_rhs(state, backend=backend)
             except (NotImplementedError, ModuleNotFoundError) as err:

--- a/pde/tools/config.py
+++ b/pde/tools/config.py
@@ -790,6 +790,7 @@ def environment() -> dict[str, Any]:
     from pde import config
 
     from .. import __version__ as package_version
+    from ..backends import available_backends
     from ..backends.numba.utils import numba_environment
     from . import mpi
     from .plotting import get_plotting_context
@@ -837,11 +838,10 @@ def environment() -> dict[str, Any]:
     packages -= set(packages_min)
     result["optional packages"] = get_package_versions(sorted(packages))
 
-    backend = {}
+    backend = {"available": available_backends()}
     if module_available("numba"):
         backend["numba"] = numba_environment()
-    if backend:
-        result["backend"] = backend
+    result["backend"] = backend
 
     # add information about MPI environment
     if mpi.initialized:

--- a/tests/backends/test_registry.py
+++ b/tests/backends/test_registry.py
@@ -1,0 +1,64 @@
+"""Test the backend registry.
+
+.. codeauthor:: David Zwicker <david.zwicker@ds.mpg.de>
+"""
+
+import pytest
+
+from pde import config
+from pde.backends import (
+    BackendBase,
+    available_backends,
+    backend_registry,
+    registered_backends,
+)
+from pde.backends.registry import BackendRegistry
+from pde.tools.misc import module_available
+
+
+def test_backend_availability():
+    """Test whether the availability of the standard backends is detected."""
+    # backends whose packages are hard dependencies of `py-pde`
+    assert backend_registry.is_available("numpy")
+    assert backend_registry.is_available("numba")
+
+    # optional backends are only available when their package is installed
+    for name in ["jax", "torch"]:
+        assert backend_registry.is_available(name) == module_available(name)
+
+    # additional information after a colon does not affect the check
+    assert backend_registry.is_available("numba:parallel")
+
+    # the default backend must obviously be usable
+    assert backend_registry.is_available("default")
+
+    # unknown backends are simply reported as being unavailable
+    assert not backend_registry.is_available("not_a_backend")
+
+
+def test_available_backends():
+    """Test the list of available backends."""
+    available = available_backends()
+    assert "numpy" in available
+    assert set(available) <= set(registered_backends())
+    assert all(backend_registry.is_available(name) for name in available)
+
+
+def test_backend_availability_custom():
+    """Test the availability of custom backends."""
+    registry = BackendRegistry()
+    with config():  # registering a package also adds a node to the global config
+        registry.register_package("dummy", "not.a.module", requires=["not_a_module"])
+        assert not registry.is_available("dummy")
+
+        registry.register_package("simple", "not.a.module")
+        assert registry.is_available("simple")  # no requirements => always available
+
+        # instantiated backends are available, even without a registered package
+        class MyBackend(BackendBase): ...
+
+        registry.register_backend(MyBackend({}, name="my_backend"))
+        assert registry.is_available("my_backend")
+
+        with pytest.raises(RuntimeError):
+            registry.register_package("dummy", "not.a.module")


### PR DESCRIPTION
Backends are now registered with the python modules they need, so we can tell whether a
backend can be used before importing it:

    BackendRegistry.is_available("torch")
    pde.available_backends()

`PDEBase.determine_backend` uses this to skip backends whose packages are missing instead
of relying on the import error raised while building the rhs, which also removes the TODO
that pointed at this issue. `environment()` now also reports the available backends.

Closes #762
