### PR TITLE
Add plot type for nematic tensor fields

### DIFF
--- a/examples/fields/plot_nematic_field.py
+++ b/examples/fields/plot_nematic_field.py
@@ -1,0 +1,21 @@
+r"""
+Plotting a nematic field
+========================
+
+This example shows how to visualize a nematic tensor field
+:math:`\boldsymbol Q = S(\boldsymbol n \otimes \boldsymbol n - \mathbb{1}/2)`.
+The field shown here contains a :math:`+\frac12` defect at the origin, where the
+director :math:`\boldsymbol n` rotates by :math:`\pi` around the defect and the nematic
+order :math:`S` vanishes.
+"""
+
+from pde import CartesianGrid, Tensor2Field
+
+grid = CartesianGrid([[-2, 2], [-2, 2]], 24)
+
+order = "tanh(2 * sqrt(x**2 + y**2))"  # nematic order vanishing at the defect
+q_xx = f"0.5 * {order} * x / sqrt(x**2 + y**2)"
+q_xy = f"0.5 * {order} * y / sqrt(x**2 + y**2)"
+field = Tensor2Field.from_expression(grid, [[q_xx, q_xy], [q_xy, f"-({q_xx})"]])
+
+field.plot(kind="nematic", title="Nematic field with a $+1/2$ defect")

--- a/pde/fields/datafield_base.py
+++ b/pde/fields/datafield_base.py
@@ -43,57 +43,6 @@ if TYPE_CHECKING:
 TDataField = TypeVar("TDataField", bound="DataFieldBase")
 
 
-def _prepare_vector_data(
-    data: dict[str, Any],
-    *,
-    transpose: bool = False,
-    max_points: int | None = None,
-) -> dict[str, Any]:
-    """Adjust data of a 2d vector plot and add information about its shape.
-
-    Args:
-        data (dict):
-            Information about the vector field, which needs to contain the items `x`,
-            `y`, `data_x`, `data_y`, `label_x`, `label_y`, and `extent`. Note that this
-            dictionary is modified in place.
-        transpose (bool):
-            Determines whether the transpose of the data should be plotted.
-        max_points (int):
-            The maximal number of points that is used along each axis. This option can
-            be used to sub-sample the data. `None` indicates that all points are used.
-
-    Returns:
-        dict: The modified data
-    """
-    if transpose:
-        data["x"], data["y"] = data["y"], data["x"]
-        data["data_x"], data["data_y"] = data["data_y"].T, data["data_x"].T
-        data["label_x"], data["label_y"] = data["label_y"], data["label_x"]
-        data["extent"] = data["extent"][2:] + data["extent"][:2]
-
-    if max_points is not None:
-        # reduce the sampling of the vector points
-        for axis, size in enumerate(data["data_x"].shape):
-            if size > max_points:
-                # sub-sample the data
-                idx_f = np.linspace(0, size - 1, max_points)
-                idx_i = np.round(idx_f).astype(int)
-
-                data["data_x"] = np.take(data["data_x"], idx_i, axis=axis)
-                data["data_y"] = np.take(data["data_y"], idx_i, axis=axis)
-                if axis == 0:
-                    data["x"] = data["x"][idx_i]
-                elif axis == 1:
-                    data["y"] = data["y"][idx_i]
-                else:
-                    msg = "Only supports 2d grids"
-                    raise RuntimeError(msg)
-
-    data["shape"] = data["data_x"].shape
-    data["size"] = data["data_x"].size
-    return data
-
-
 class DataFieldBase(FieldBase, metaclass=ABCMeta):
     """Abstract base class for describing fields of single entities."""
 
@@ -1613,3 +1562,54 @@ def _symmetrize_vmin_vmax(
 
     # set the values if they are numeric
     return vmin, vmax  # type: ignore
+
+
+def _prepare_vector_data(
+    data: dict[str, Any],
+    *,
+    transpose: bool = False,
+    max_points: int | None = None,
+) -> dict[str, Any]:
+    """Adjust data of a 2d vector plot and add information about its shape.
+
+    Args:
+        data (dict):
+            Information about the vector field, which needs to contain the items `x`,
+            `y`, `data_x`, `data_y`, `label_x`, `label_y`, and `extent`. Note that this
+            dictionary is modified in place.
+        transpose (bool):
+            Determines whether the transpose of the data should be plotted.
+        max_points (int):
+            The maximal number of points that is used along each axis. This option can
+            be used to sub-sample the data. `None` indicates that all points are used.
+
+    Returns:
+        dict: The modified data
+    """
+    if transpose:
+        data["x"], data["y"] = data["y"], data["x"]
+        data["data_x"], data["data_y"] = data["data_y"].T, data["data_x"].T
+        data["label_x"], data["label_y"] = data["label_y"], data["label_x"]
+        data["extent"] = data["extent"][2:] + data["extent"][:2]
+
+    if max_points is not None:
+        # reduce the sampling of the vector points
+        for axis, size in enumerate(data["data_x"].shape):
+            if size > max_points:
+                # sub-sample the data
+                idx_f = np.linspace(0, size - 1, max_points)
+                idx_i = np.round(idx_f).astype(int)
+
+                data["data_x"] = np.take(data["data_x"], idx_i, axis=axis)
+                data["data_y"] = np.take(data["data_y"], idx_i, axis=axis)
+                if axis == 0:
+                    data["x"] = data["x"][idx_i]
+                elif axis == 1:
+                    data["y"] = data["y"][idx_i]
+                else:
+                    msg = "Only supports 2d grids"
+                    raise RuntimeError(msg)
+
+    data["shape"] = data["data_x"].shape
+    data["size"] = data["data_x"].size
+    return data

--- a/pde/fields/datafield_base.py
+++ b/pde/fields/datafield_base.py
@@ -1394,12 +1394,12 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         if method == "quiver":
             # update the data of a quiver plot
             data = self.get_vector_data(**data_kws)
-            reference.element.set_UVC(data["data_x"], data["data_y"])
+            reference.element.set_UVC(data["data_x"].T, data["data_y"].T)
 
         elif method == "nematic":
             # update the data of a quiver plot showing the nematic director
             data = self.get_nematic_data(**data_kws)
-            reference.element.set_UVC(data["data_x"], data["data_y"])
+            reference.element.set_UVC(data["data_x"].T, data["data_y"].T)
 
         elif method == "streamplot":
             # update a streamplot by redrawing it completely

--- a/pde/fields/datafield_base.py
+++ b/pde/fields/datafield_base.py
@@ -43,6 +43,57 @@ if TYPE_CHECKING:
 TDataField = TypeVar("TDataField", bound="DataFieldBase")
 
 
+def _prepare_vector_data(
+    data: dict[str, Any],
+    *,
+    transpose: bool = False,
+    max_points: int | None = None,
+) -> dict[str, Any]:
+    """Adjust data of a 2d vector plot and add information about its shape.
+
+    Args:
+        data (dict):
+            Information about the vector field, which needs to contain the items `x`,
+            `y`, `data_x`, `data_y`, `label_x`, `label_y`, and `extent`. Note that this
+            dictionary is modified in place.
+        transpose (bool):
+            Determines whether the transpose of the data should be plotted.
+        max_points (int):
+            The maximal number of points that is used along each axis. This option can
+            be used to sub-sample the data. `None` indicates that all points are used.
+
+    Returns:
+        dict: The modified data
+    """
+    if transpose:
+        data["x"], data["y"] = data["y"], data["x"]
+        data["data_x"], data["data_y"] = data["data_y"].T, data["data_x"].T
+        data["label_x"], data["label_y"] = data["label_y"], data["label_x"]
+        data["extent"] = data["extent"][2:] + data["extent"][:2]
+
+    if max_points is not None:
+        # reduce the sampling of the vector points
+        for axis, size in enumerate(data["data_x"].shape):
+            if size > max_points:
+                # sub-sample the data
+                idx_f = np.linspace(0, size - 1, max_points)
+                idx_i = np.round(idx_f).astype(int)
+
+                data["data_x"] = np.take(data["data_x"], idx_i, axis=axis)
+                data["data_y"] = np.take(data["data_y"], idx_i, axis=axis)
+                if axis == 0:
+                    data["x"] = data["x"][idx_i]
+                elif axis == 1:
+                    data["y"] = data["y"][idx_i]
+                else:
+                    msg = "Only supports 2d grids"
+                    raise RuntimeError(msg)
+
+    data["shape"] = data["data_x"].shape
+    data["size"] = data["data_x"].size
+    return data
+
+
 class DataFieldBase(FieldBase, metaclass=ABCMeta):
     """Abstract base class for describing fields of single entities."""
 
@@ -1052,6 +1103,20 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def get_nematic_data(self, transpose: bool = False, **kwargs) -> dict[str, Any]:
+        r"""Return data for a nematic plot of the field.
+
+        Args:
+            transpose (bool):
+                Determines whether the transpose of the data should be plotted.
+            **kwargs: Additional parameters are forwarded to
+                `grid.get_image_data`
+
+        Returns:
+            dict: Information useful for plotting a nematic field
+        """
+        raise NotImplementedError
+
     def _plot_line(
         self,
         ax,
@@ -1240,7 +1305,7 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         self,
         ax,
         *,
-        method: Literal["quiver", "streamplot"] = "quiver",
+        method: Literal["quiver", "streamplot", "nematic"] = "quiver",
         max_points: int | None = 16,
         **kwargs,
     ) -> PlotReference:
@@ -1250,10 +1315,12 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
             ax (:class:`matplotlib.axes.Axes`):
                 Figure axes to be used for plotting.
             method (str):
-                Plot type that is used. This can be either `quiver` or `streamplot`.
+                Plot type that is used. This can be `quiver`, `streamplot`, or
+                `nematic`. The latter draws headless arrows along the nematic director
+                and is only supported by :class:`~pde.fields.tensorial.Tensor2Field`.
             max_points (int):
                 The maximal number of points that is used along each axis. This argument
-                is only used for quiver plots. `None` indicates all points are used.
+                is not used for stream plots. `None` indicates all points are used.
             **kwargs:
                 Additional keyword arguments are passed to
                 :meth:`~pde.field.base.DataFieldBase.get_vector_data` and
@@ -1277,6 +1344,18 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
             # plot vector field using a quiver plot
             data_kws["max_points"] = max_points
             data = self.get_vector_data(**data_kws)
+            element = ax.quiver(
+                data["x"], data["y"], data["data_x"].T, data["data_y"].T, **kwargs
+            )
+
+        elif method == "nematic":
+            # plot the nematic director using a quiver plot without arrow heads
+            data_kws["max_points"] = max_points
+            data = self.get_nematic_data(**data_kws)
+            kwargs.setdefault("pivot", "mid")
+            kwargs.setdefault("headwidth", 0)
+            kwargs.setdefault("headlength", 0)
+            kwargs.setdefault("headaxislength", 0)
             element = ax.quiver(
                 data["x"], data["y"], data["data_x"].T, data["data_y"].T, **kwargs
             )
@@ -1315,6 +1394,11 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         if method == "quiver":
             # update the data of a quiver plot
             data = self.get_vector_data(**data_kws)
+            reference.element.set_UVC(data["data_x"], data["data_y"])
+
+        elif method == "nematic":
+            # update the data of a quiver plot showing the nematic director
+            data = self.get_nematic_data(**data_kws)
             reference.element.set_UVC(data["data_x"], data["data_y"])
 
         elif method == "streamplot":
@@ -1361,7 +1445,7 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         Args:
             kind (str):
                 Determines the visualizations. Supported values are `image`,
-                `line`, `vector`, or `interactive`. Alternatively, `auto`
+                `line`, `vector`, `nematic`, or `interactive`. Alternatively, `auto`
                 determines the best visualization based on the field itself.
             {PLOT_ARGS}
             **kwargs:
@@ -1399,6 +1483,12 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
               - `max_points` Sets max. number of points along each axis in quiver plots
               - Additional arguments are passed to :func:`matplotlib.pyplot.quiver` or
                 :func:`matplotlib.pyplot.streamplot`.
+
+            * ``kind == "nematic"``:
+
+              - `transpose` Determines whether the transpose of the data is plotted
+              - `max_points` Sets max. number of points along each axis
+              - Additional arguments are passed to :func:`matplotlib.pyplot.quiver`
         """
         # determine the correct kind of plotting
         if kind == "auto":
@@ -1422,6 +1512,10 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
             kind = "vector"
             kwargs["method"] = "streamplot"
 
+        elif kind == "nematic":
+            kind = "vector"
+            kwargs["method"] = "nematic"
+
         # do the actual plotting
         if kind == "image":
             reference = self._plot_image(**kwargs)
@@ -1432,7 +1526,7 @@ class DataFieldBase(FieldBase, metaclass=ABCMeta):
         else:
             msg = (
                 f"Unsupported plot `{kind}`. Possible choices are `image`, `line`, "
-                "`vector`, or `auto`."
+                "`vector`, `nematic`, or `auto`."
             )
             raise ValueError(msg)
 

--- a/pde/fields/tensorial.py
+++ b/pde/fields/tensorial.py
@@ -5,15 +5,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
 from ..grids.base import DimensionError, GridBase
+from ..grids.cartesian import CartesianGrid
 from ..tools.docstrings import fill_in_docstring
 from ..tools.misc import get_common_dtype
 from ..tools.plotting import PlotReference, plot_on_figure
-from .datafield_base import DataFieldBase
+from .datafield_base import DataFieldBase, _prepare_vector_data
 from .scalar import ScalarField
 from .vectorial import VectorField
 
@@ -493,6 +494,63 @@ class Tensor2Field(DataFieldBase):
         if make_traceless:
             res.convert("traceless", inplace=True)
         return res
+
+    def get_nematic_data(
+        self, transpose: bool = False, max_points: int | None = None, **kwargs
+    ) -> dict[str, Any]:
+        r"""Return data for a nematic plot of the field.
+
+        The tensor field is interpreted as a nematic order parameter, i.e., only the
+        symmetric, traceless part :math:`\boldsymbol{Q}` of the tensor is used. In two
+        dimensions, this part can be written as
+
+        .. math::
+            \boldsymbol{Q} = S \left(
+                \boldsymbol{n} \otimes \boldsymbol{n} - \frac{\mathbb{1}}{2}
+            \right)
+
+        where the director :math:`\boldsymbol{n}` is a unit vector and the nematic order
+        :math:`S \ge 0` is the difference of the two eigenvalues of
+        :math:`\boldsymbol{Q}`. The returned vectors are aligned with the director and
+        their length is given by the nematic order.
+
+        Note that the director is only defined up to its sign, so the returned vectors
+        should be plotted without arrow heads; see the `nematic` plot kind of
+        :meth:`~pde.fields.datafield_base.DataFieldBase.plot`.
+
+        Args:
+            transpose (bool):
+                Determines whether the transpose of the data should be plotted.
+            max_points (int):
+                The maximal number of points that is used along each axis. This
+                option can be used to sub-sample the data.
+            **kwargs:
+                Additional parameters forwarded to `grid.get_image_data`
+
+        Returns:
+            dict: Information useful for plotting a nematic field
+        """
+        if not isinstance(self.grid, CartesianGrid) or self.grid.dim != 2:
+            msg = "Nematic data is only available for 2d Cartesian grids"
+            raise DimensionError(msg)
+        if self.is_complex:
+            self._logger.warning("Only the real part of complex data is shown")
+
+        # extract the symmetric, traceless part, which reads [[a, b], [b, -a]]
+        tensor = self.data.real
+        a = 0.5 * (tensor[0, 0] - tensor[1, 1])
+        b = 0.5 * (tensor[0, 1] + tensor[1, 0])
+
+        # determine the nematic order and the orientation of the director
+        order = 2 * np.hypot(a, b)  # difference between the two eigenvalues
+        angle = 0.5 * np.arctan2(b, a)  # orientation of the leading eigenvector
+        director = np.array([order * np.cos(angle), order * np.sin(angle)])
+
+        # extract the image data
+        data = self.grid.get_vector_data(director, **kwargs)
+        data["title"] = self.label
+
+        return _prepare_vector_data(data, transpose=transpose, max_points=max_points)
 
     def _update_plot_components(self, reference: list[list[PlotReference]]) -> None:
         """Update a component plot with the current field values.

--- a/pde/fields/vectorial.py
+++ b/pde/fields/vectorial.py
@@ -14,7 +14,7 @@ from ..grids.cartesian import CartesianGrid
 from ..tools.docstrings import fill_in_docstring
 from ..tools.misc import get_common_dtype
 from ..tools.plotting import PlotReference, plot_on_figure
-from .datafield_base import DataFieldBase
+from .datafield_base import DataFieldBase, _prepare_vector_data
 from .scalar import ScalarField
 
 if TYPE_CHECKING:
@@ -474,36 +474,7 @@ class VectorField(DataFieldBase):
         data = self.grid.get_vector_data(self.data.real, **kwargs)
         data["title"] = self.label
 
-        # transpose the data if requested
-        if transpose:
-            data["x"], data["y"] = data["y"], data["x"]
-            data["data_x"], data["data_y"] = data["data_y"].T, data["data_x"].T
-            data["label_x"], data["label_y"] = data["label_y"], data["label_x"]
-            data["extent"] = data["extent"][2:] + data["extent"][:2]
-
-        # reduce the sampling of the vector points
-        if max_points is not None:
-            shape = data["data_x"].shape
-            for axis, size in enumerate(shape):
-                if size > max_points:
-                    # sub-sample the data
-                    idx_f = np.linspace(0, size - 1, max_points)
-                    idx_i = np.round(idx_f).astype(int)
-
-                    data["data_x"] = np.take(data["data_x"], idx_i, axis=axis)
-                    data["data_y"] = np.take(data["data_y"], idx_i, axis=axis)
-                    if axis == 0:
-                        data["x"] = data["x"][idx_i]
-                    elif axis == 1:
-                        data["y"] = data["y"][idx_i]
-                    else:
-                        msg = "Only supports 2d grids"
-                        raise RuntimeError(msg)
-
-        data["shape"] = data["data_x"].shape
-        data["size"] = data["data_x"].size
-
-        return data
+        return _prepare_vector_data(data, transpose=transpose, max_points=max_points)
 
     @fill_in_docstring
     def interpolate_to_grid(

--- a/tests/fields/test_tensorial_fields.py
+++ b/tests/fields/test_tensorial_fields.py
@@ -326,7 +326,9 @@ def test_nematic_plotting_2d(transpose, rng):
     field = Tensor2Field.random_uniform(grid, 0.1, 0.9, rng=rng)
 
     ref = field.plot(kind="nematic", transpose=transpose)
-    field._update_plot(ref)
+    arrows = np.array([ref.element.U, ref.element.V])
+    field._update_plot(ref)  # updating with the same data must not change arrows
+    np.testing.assert_allclose([ref.element.U, ref.element.V], arrows)
 
     # test sub-sampling
     grid = UnitGrid([32, 15])

--- a/tests/fields/test_tensorial_fields.py
+++ b/tests/fields/test_tensorial_fields.py
@@ -16,6 +16,7 @@ from pde import (
     get_backend,
 )
 from pde.fields.base import FieldBase
+from pde.grids.base import DimensionError
 
 
 def test_tensors_basic(rng):
@@ -294,3 +295,51 @@ def test_tensor_convert():
 
     with pytest.raises(ValueError):
         tf.convert("undefined")
+
+
+@pytest.mark.parametrize("angle", [0, 0.3, np.pi / 2, 2.5])
+def test_nematic_data(angle):
+    """Test the nematic data extracted from a tensor field."""
+    grid = UnitGrid([3, 4])
+    order = 1.5
+    director = np.array([np.cos(angle), np.sin(angle)])
+    tensor = order * (np.outer(director, director) - np.eye(2) / 2)
+    field = Tensor2Field(grid, np.einsum("ij,kl->ijkl", tensor, np.ones(grid.shape)))
+
+    data = field.get_nematic_data()
+    assert data["shape"] == grid.shape
+    np.testing.assert_allclose(np.hypot(data["data_x"], data["data_y"]), order)
+    angles = np.arctan2(data["data_y"], data["data_x"]) % np.pi
+    np.testing.assert_allclose(angles, angle % np.pi, atol=1e-14)
+
+    # anti-symmetric parts and the trace do not affect the nematic data
+    field += Tensor2Field.from_expression(grid, [["x", "y"], ["-y", "x"]])
+    data_mod = field.get_nematic_data()
+    np.testing.assert_allclose(data_mod["data_x"], data["data_x"], atol=1e-14)
+    np.testing.assert_allclose(data_mod["data_y"], data["data_y"], atol=1e-14)
+
+
+@pytest.mark.parametrize("transpose", [True, False])
+def test_nematic_plotting_2d(transpose, rng):
+    """Test plotting nematic tensor fields."""
+    grid = UnitGrid([3, 4])
+    field = Tensor2Field.random_uniform(grid, 0.1, 0.9, rng=rng)
+
+    ref = field.plot(kind="nematic", transpose=transpose)
+    field._update_plot(ref)
+
+    # test sub-sampling
+    grid = UnitGrid([32, 15])
+    field = Tensor2Field.random_uniform(grid, 0.1, 0.9, rng=rng)
+    ref = field.plot(kind="nematic", transpose=transpose, max_points=7)
+    assert len(ref.element.U) == 7 * 7
+
+
+def test_nematic_data_unsupported_grids():
+    """Test that nematic data is only supported for 2d Cartesian grids."""
+    with pytest.raises(DimensionError):
+        Tensor2Field(UnitGrid([3])).get_nematic_data()
+    with pytest.raises(DimensionError):
+        Tensor2Field(UnitGrid([3, 4, 5])).get_nematic_data()
+    with pytest.raises(DimensionError):
+        Tensor2Field(PolarSymGrid(3, 4)).get_nematic_data()

--- a/tests/fields/test_vectorial_fields.py
+++ b/tests/fields/test_vectorial_fields.py
@@ -251,6 +251,12 @@ def test_vector_plotting_2d(transpose, rng):
         ref = field.plot(method=method, transpose=transpose)
         field._update_plot(ref)
 
+    # updating a quiver plot with the same data must not change the arrows
+    ref = field.plot(method="quiver", transpose=transpose, max_points=None)
+    arrows = np.array([ref.element.U, ref.element.V])
+    field._update_plot(ref)
+    np.testing.assert_allclose([ref.element.U, ref.element.V], arrows)
+
     # test sub-sampling
     grid = UnitGrid([32, 15])
     field = VectorField.random_uniform(grid, 0.1, 0.9, rng=rng)


### PR DESCRIPTION
`Tensor2Field.get_nematic_data` returns the director and the nematic order of the
symmetric, traceless part of the tensor, so a general tensor field is interpreted as the
nematic order parameter Q = S (n x n - 1/2). The associated plot kind draws these as
headless arrows, since the director is only defined up to its sign:

    field.plot(kind="nematic")

This only works for 2d Cartesian grids for now and raises `DimensionError` otherwise. The
transposing and sub-sampling of the plot data is shared with `VectorField` through a small
helper, and updating the plot goes through the existing vector plot machinery, so trackers
work as usual.

While testing the update I noticed that `_update_vector_plot` passed the data to
`set_UVC` without the transpose that the initial `quiver` call uses, so updated arrows
were scrambled on non-square grids. This is fixed here for both quiver and nematic plots,
with a test.

Closes #707
